### PR TITLE
Rename gem from mail_checker => ruby-mailchecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm install mailchecker
 
 Ruby
 ```bash
-gem install mail_checker
+gem install ruby-mailchecker
 ```
 
 __We accept pull-requests for other package manager__.

--- a/platform/ruby/ruby-mailchecker.rb
+++ b/platform/ruby/ruby-mailchecker.rb
@@ -1,0 +1,1 @@
+require 'mail_checker'

--- a/ruby-mailchecker.gemspec
+++ b/ruby-mailchecker.gemspec
@@ -1,6 +1,6 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
-  spec.name          = 'mail_checker'
+  spec.name          = 'ruby-mailchecker'
   spec.version       = '0.1.0'
   spec.authors       = ['Francois-Guillaume Ribreau', 'Jacob Burenstam']
   spec.email         = ['github@fgribreau.com']
@@ -10,6 +10,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/FGRibreau/mailchecker'
   spec.license       = 'MIT'
 
-  spec.files         = ['platform/ruby/mail_checker.rb']
+  spec.files         = ['platform/ruby/mail_checker.rb', 'platform/ruby/ruby-mailchecker.rb']
   spec.require_paths = ['platform/ruby']
 end


### PR DESCRIPTION
:warning:  __Gem is not published__ on [RubyGems](https://rubygems.org) yet.

Don't know if you have an account there already, but if not you could always create it (otherwise ping me..).