### PR TITLE
Update link to node-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Cross-language email validation. Backed by a [database](./list.json) of **1979 throwable email providers**.
 
-* Validate the format of your email (uses [node-validator](https://github.com/chriso/node-validator/blob/master/lib/validators.js#L27) email regex underneath and `FILTER_VALIDATE_EMAIL` for PHP)
+* Validate the format of your email (uses [validator.js](https://github.com/chriso/validator.js/blob/master/validator.js#L38) email regex underneath and `FILTER_VALIDATE_EMAIL` for PHP)
 * Validate if the email is not a **temporary mail** (yopmail-like..., [add your own dataset to list.json](./list.json))
 
 This will be very helpful when you have to contact your users and you want to avoid errors causing lack of communication or want to block "spamboxes".


### PR DESCRIPTION
The node-validator project was renamed, and the repo was moved. This changes reflects the new name (validator.js) and updates the URL to point to the new repo.

I tried to guess what part of the new file to link to, but please let me know if it should point elsewhere.