### PR TITLE
Extract blacklisted? method for Ruby implementation

### DIFF
--- a/platform/ruby/mail_checker.rb
+++ b/platform/ruby/mail_checker.rb
@@ -8,7 +8,7 @@ module MailChecker
   def self.valid?(email)
     return false unless valid_email?(email)
 
-    !extract_all_domain_suffixes(email).any? { |domain| BLACKLIST.include?(domain) }
+    !blacklisted?(email)
   end
 
   def self.valid_email?(email)
@@ -17,8 +17,12 @@ module MailChecker
     email =~ EMAIL_REGEX
   end
 
+  def self.blacklisted?(email)
+    extract_all_domain_suffixes(email).any? { |domain| BLACKLIST.include?(domain) }
+  end
+
   def self.extract_all_domain_suffixes(email)
-    domain = email.gsub(/.+@([^.]+)/, '\1').downcase
+    domain = email.to_s.gsub(/.+@([^.]+)/, '\1').downcase
 
     domain_components = domain.split('.')
 

--- a/platform/ruby/mail_checker.tmpl.rb
+++ b/platform/ruby/mail_checker.tmpl.rb
@@ -8,7 +8,7 @@ module MailChecker
   def self.valid?(email)
     return false unless valid_email?(email)
 
-    !extract_all_domain_suffixes(email).any? { |domain| BLACKLIST.include?(domain) }
+    !blacklisted?(email)
   end
 
   def self.valid_email?(email)
@@ -17,8 +17,12 @@ module MailChecker
     email =~ EMAIL_REGEX
   end
 
+  def self.blacklisted?(email)
+    extract_all_domain_suffixes(email).any? { |domain| BLACKLIST.include?(domain) }
+  end
+
   def self.extract_all_domain_suffixes(email)
-    domain = email.gsub(/.+@([^.]+)/, '\1').downcase
+    domain = email.to_s.gsub(/.+@([^.]+)/, '\1').downcase
 
     domain_components = domain.split('.')
 


### PR DESCRIPTION
We need this since we use a weaker email validation regex internally, so some of our email addresses may be malformed w.r.t. the stricter MailChecker regex. Thus by exposing `blacklisted?` we can implement our own `valid_email?` method and still use MailChecker's `blacklisted?` method.

This is a backwards-compatible change, so does not require a major version bump!