### PR TITLE
Update Ruby example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ if not MailChecker.is_valid('bla@example.com'):
 ```ruby
 require 'mail_checker'
 
-unless MailChecker('myemail@yopmail.com')
-  fail('O RLY!')
-end
-
 unless MailChecker.valid?('myemail@yopmail.com')
   fail('O RLY!')
 end


### PR DESCRIPTION
Remove "old" way of calling MailChecker from Ruby example.

Saw that the examples have been updated for other languages too and its more naturally to write it as `MailChecker.valid?(email)` than `MailChecker(email)` in Ruby. 