### PR TITLE
PHP class: convert isBlacklisted method in public

### DIFF
--- a/platform/php/MailChecker.php
+++ b/platform/php/MailChecker.php
@@ -31,7 +31,7 @@ class MailChecker {
         }
     }
 
-    private static function isBlacklisted($email) {
+    public static function isBlacklisted($email) {
         $parts = explode("@", $email);
         $domain = end($parts);
 


### PR DESCRIPTION
Hi, 

I would like to convert one of the methods in public to be able to use the black-list without validating the email using the PHP filter function. 

filter_var($email, FILTER_VALIDATE_EMAIL) doesn't validate correctly the allowed email patterns exposed in this Wikipedia article: https://en.wikipedia.org/wiki/Email_address#Local-part

Thanks for this great job, 
Kind regards. 

 