### PR TITLE
sibmail.com is a valid email provider

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -26250,7 +26250,6 @@ siatkiogrodzeniowenet.pl
 sibelor.pw
 siberask.com
 sibigkostbil.xyz
-sibmail.com
 sicamail.ga
 sickseo.co.uk
 sidamail.ga


### PR DESCRIPTION
As I mentioned in #166, sibmail.com is a valid email provider. It was re-introduced recently in #185, so please remove it.