### PR TITLE
Remove qq.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -24054,7 +24054,6 @@ qpi8iqrh8wtfpee3p.ml
 qpi8iqrh8wtfpee3p.tk
 qpptplypblyp052.cf
 qpulsa.com
-qq.com
 qq.my
 qq152.com
 qq163.com


### PR DESCRIPTION
It has been discussed in #50, removed in #73 but was re-introduced in #185.