### PR TITLE
removing com.ar for list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -7305,7 +7305,6 @@ coloninsta.tk
 colorado-nedv.ru
 colorweb.cf
 com-posted.org
-com.ar
 comagrilsa.com
 comantra.net
 combrotech77rel.gq


### PR DESCRIPTION
com.ar is a domain who belongs to companies and individuals resident in Argentina.