### PR TITLE
Fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/FGRibreau/mailchecker
+module github.com/FGRibreau/mailchecker/v3
 
 go 1.13


### PR DESCRIPTION
I didn't realize that this library is already on `v3` for the major version.

For go modules, once you start tagging `v2` and onward, the import path must be updated to include the version.

This PR fixes this issue as the current version cannot be imported by Go modules correctly. Once this is merged, can you please tag a new version to allow Go to import it properly?