### PR TITLE
Remove the email provider cock.li

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -7230,7 +7230,6 @@ coccx1ajbpsz.ml
 coccx1ajbpsz.tk
 cochatz.ga
 cochranmail.men
-cock.li
 coclaims.com
 coco.be
 cocochaneljapan.com


### PR DESCRIPTION
[https://cock.li](https://cock.li) is a legitimate email service and doesn't offer disposable emails. 