### PR TITLE
Ensure types are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Cross-language temporary (disposable/throwaway) email detection library. Covers hundreds fake email providers.",
   "main": "platform/node/index.js",
   "files": [
-    "platform/node/index.js"
+    "platform/node/index.js",
+    "types.d.ts
   ],
   "scripts": {
     "build": "node lib/clean.js && node gen.js",


### PR DESCRIPTION
Types were missed in the `files` section of `package.json`, meaning they aren't published in the npm version of this package.