### PR TITLE
Remove gmx.com from the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -12790,7 +12790,6 @@ gmmx.com
 gmojl.com
 gmsdfhail.com
 gmssail.com
-gmx.com
 gmx.dns-cloud.net
 gmx.dnsabr.com
 gmx.es


### PR DESCRIPTION
gmx.com is not a temporary email address.

https://en.wikipedia.org/wiki/GMX_Mail#gmx.com