### PR TITLE
remove hush.com from list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -14436,7 +14436,6 @@ hurify1.com
 hurramm.us
 hurrijian.us
 hush.ai
-hush.com
 hushclouds.com
 hushmail.cf
 huskion.net


### PR DESCRIPTION
the hushmail provider (@hushmail.com) was removed from this list in 2016, but hush.com was recently added by https://github.com/FGRibreau/mailchecker/pull/183. We've been in contact with a hushmail user who tried to sign up with a hush.com email, which was blocked. https://www.hushmail.com/ seems legit, their intention is definitely not to be a spam/temp provider. 