### PR TITLE
Added maxresistance.com public email provider

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -19390,6 +19390,7 @@ maxmail.in
 maxmail.info
 maxpedia.ro
 maxprice.co
+maxresistance.com
 maxrollspins.co
 maxxdrv.ru
 mayaaaa.cf


### PR DESCRIPTION
Public Email Service
maxresistance.com

Public Email Service. This is a public email service to prevent SPAM in the first place. Keep in mind that we don't allow sending messages to the internet at all as ...