### PR TITLE
php add addCustomDomains

### DIFF
--- a/platform/php/MailChecker.php
+++ b/platform/php/MailChecker.php
@@ -18,6 +18,13 @@ class MailChecker
     {
         self::$blacklist = require __DIR__.'/blacklist.php';
     }
+  
+    public static function addCustomDomains(array $domains): void
+    {
+        foreach ($domains as $domain) {
+            self::$blacklist[$domain] = true;
+        }
+    }
 
     public static function isValid(string $email): bool
     {


### PR DESCRIPTION
This commit adds the possibility to add your own custom domains to the blacklist.

Example usage:
```php
MailChecker::addCustomDomains([
    'youtube.com',
    'google.com',
]);
```