### PR TITLE
Remove cock.li domains

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -1053,7 +1053,6 @@
 41uno.com
 41uno.net
 41v1relaxn.com
-420blaze.it
 420pure.com
 42o.org
 43adsdzxcz.info
@@ -2164,7 +2163,6 @@ aaaaa7.pl
 aaaaa8.pl
 aaaaa9.pl
 aaaf.ru
-aaathats3as.com
 aaaw45e.com
 aabagfdgks.net
 aacxb.xyz
@@ -2862,7 +2860,6 @@ airjordanspascher1.com
 airjordansshoes2014.com
 airjordansstocker.com
 airknox.com
-airmail.cc
 airmail.tech
 airmailhub.com
 airmax-sale2013club.us
@@ -7342,7 +7339,6 @@ cobarekyo1.ml
 cobete.cf
 cobin2hood.com
 cobin2hood.company
-cocaine.ninja
 coccx1ajbpsz.cf
 coccx1ajbpsz.ga
 coccx1ajbpsz.gq
@@ -7350,9 +7346,6 @@ coccx1ajbpsz.ml
 coccx1ajbpsz.tk
 cochatz.ga
 cochranmail.men
-cock.email
-cock.li
-cock.lu
 coclaims.com
 coco.be
 cocochaneljapan.com
@@ -7835,7 +7828,6 @@ culdemamie.com
 cult-reno.ru
 cultmovie.com
 cum.sborra.tk
-cumallover.me
 cumangeblog.net
 cumanuallyo.com
 cumbeeclan.com
@@ -8572,8 +8564,6 @@ dibbler6.pl
 dibbler7.pl
 dichalorli.xyz
 dichvuseothue.com
-dicksinhisan.us
-dicksinmyan.us
 dicountsoccerjerseys.com
 dicyemail.com
 didarcrm.com
@@ -11340,7 +11330,6 @@ firef0x.gq
 firef0x.ml
 firef0x.tk
 fireflies.edu
-firemail.cc
 firemail.org.ua
 firemail.uz.ua
 firemailbox.club
@@ -12867,7 +12856,6 @@ go2usa.info
 go2vpn.net
 goasfer.com
 goashmail.com
-goat.si
 gobet889.online
 gobet889bola.com
 gobet889skor.com
@@ -14189,7 +14177,6 @@ hornet.ie
 hornyalwary.top
 horoskopde.com
 horsebarninfo.com
-horsefucker.org
 horsepoops.info
 horvathurtablahoz.ml
 host-info.com
@@ -18177,8 +18164,6 @@ loveme.com
 lovemeet.faith
 lovemeleaveme.com
 lovemue.com
-loves.dicksinhisan.us
-loves.dicksinmyan.us
 lovesea.gq
 lovesoftware.net
 lovesunglasses.info
@@ -19645,7 +19630,6 @@ memecituenakganasli.ml
 memecituenakganasli.tk
 memeil.top
 memem.uni.me
-memeware.net
 memkottawaprofilebacks.com
 memorygalore.com
 memp.net
@@ -20998,7 +20982,6 @@ nat4.us
 natachasteven.com
 nate.co.kr
 national-escorts.co.uk
-national.shitposting.agency
 nationalchampionshiplivestream.com
 nationalgardeningclub.com
 nationalsalesmultiplier.com
@@ -28646,7 +28629,6 @@ tf5bh7wqi0zcus.ml
 tf5bh7wqi0zcus.tk
 tf7nzhw.com
 tfgphjqzkc.pl
-tfwno.gf
 tfzav6iptxcbqviv.cf
 tfzav6iptxcbqviv.ga
 tfzav6iptxcbqviv.gq
@@ -31285,7 +31267,6 @@ wagfused.com
 waggadistrict.com
 wahab.com
 wahch-movies.net
-waifu.club
 waitingjwo.com
 wajikethanh96ger.gq
 wakacje-e.pl
@@ -31309,8 +31290,6 @@ wanko.be
 wanoptimization.info
 want2lov.us
 wantplay.site
-wants.dicksinhisan.us
-wants.dicksinmyan.us
 wapl.ga
 wapsportsmedicine.net
 waratishou.us


### PR DESCRIPTION
## Summary
Cock.li no longer provides registration and aims to be invite only email domain as it stated here [https://cock.li/register](https://cock.li/register).
By the way cock.li has never been a disposable email provider.

## Details
Is it necessary to preserve no newline at the end of the file?

List of email domains from [cock.li home page](https://cock.li/)
- cock.li
- airmail.cc
- 420blaze.it
- aaathats3as.com
- cumallover.me
- goat.si
- horsefucker.org
- national.shitposting.agency
- tfwno.gf
- cock.lu
- cock.email
- firemail.cc
- memeware.net
- cocaine.ninja
- waifu.club
- dicksinhisan.us
- loves.dicksinhisan.us
- wants.dicksinhisan.us
- dicksinmyan.us
- loves.dicksinmyan.us
- wants.dicksinmyan.us

## Related:
#245