### PR TITLE
remove swatch.com from list (existing company domain)

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -28028,7 +28028,6 @@ svywkabolml.pc.pl
 swaidaindustry.org
 swapfinancebroker.org
 swapinsta.com
-swatch.com
 sweetheartdress.net
 sweetmessage.ga
 sweetnessrice.com


### PR DESCRIPTION
The domain should not be on the list as [swatch.com](https://www.swatch.com/) is a valid company domain.