### PR TITLE
docs(CONTRIBUTING): mention Docker as prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 Before you begin:
 - Mailchecker is powered by Node.js. Check to see if you're on the right [version of node in `engines.node`](package.json).
+- Docker is used for setting up and running tests for various platforms. [Install Docker](https://www.docker.com/get-started) and make sure you have `docker` command in `PATH`.
+
 
 ### How to add new domains to the disallow list?
 


### PR DESCRIPTION
Without `docker` in `PATH` and docker daemon running, the tests would failed to run.
<img width="1451" alt="image" src="https://user-images.githubusercontent.com/12410942/139775271-a60d6f3e-997a-4b55-adbb-42647da31aa4.png">
