### PR TITLE
chore(rust): fix 'npm run setup:rust' and update to correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "setup": "npm run build && npm-run-all --max-parallel 2 --parallel setup:*",
     "setup:ruby": "docker run -i -v $(pwd):/app -w /app centurylink/ruby-base:2.2 bundler",
     "setup:clojure": "docker run -i -v $(pwd):/app -w /app clojure:lein-2.8.1 lein install",
-    "setup:rust": "docker run -i -v $(pwd)/platform/rust:/source -e CARGO_HOME=/source/cargo jimmycuadra/rust:1.19.0 cargo build",
+    "setup:rust": "docker run -i -v $(pwd)/platform/rust:/source -w /source -e CARGO_HOME=/source/cargo rust:1.38.0-slim-stretch cargo build",
     "full-build": "npm run build && npm run compile",
     "test": "npm run build && npm-run-all --max-parallel 2 --parallel test:*",
     "test:clojure": "echo 'skipping clojure test because it cant handle code too large' || docker run -i -v $(pwd):/app -w /app clojure:lein-2.8.1 lein exec test/platform.clojure.test.clj",

--- a/platform/rust/Cargo.lock
+++ b/platform/rust/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "mailchecker"
-version = "4.0.12"
+version = "4.0.13"
 dependencies = [
  "fast_chemail",
  "pretty_assertions",


### PR DESCRIPTION
https://github.com/FGRibreau/mailchecker/commit/0a75ab4f8346bf7596922d82461135411d8ba1ac#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25 updated `npm run test:rust` but forget about `npm run setup:rust`.

| Before | After |
| --- | --- |
| <img width="1679" alt="image" src="https://user-images.githubusercontent.com/12410942/139799415-bc2d03bb-2715-4b23-9b4f-53cc0389cfe7.png"> | <img width="1469" alt="image" src="https://user-images.githubusercontent.com/12410942/139799438-2d6d07ed-41fb-41ea-a6ec-1924b43983ec.png"> |
