### PR TITLE
test(elixir): SyntaxError reported as ArgumentError You must be in the repository root directory in order to run the tests

### DIFF
--- a/test/platform.elixir.test.exs
+++ b/test/platform.elixir.test.exs
@@ -5,7 +5,7 @@ ExUnit.start
 try do
   Code.require_file("mail_checker.ex", "platform/elixir/")
 rescue
-  _ -> raise ArgumentError, message: "You must be in the repository root directory in order to run the tests."
+  Code.LoadError -> raise ArgumentError, message: "You must be in the repository root directory in order to run the tests."
 end
 
 defmodule MailCheckerTest do


### PR DESCRIPTION
With a simple syntax error ...
<img width="481" alt="image" src="https://user-images.githubusercontent.com/12410942/140602869-15d3ef1c-5fb3-4a15-9b52-dd2c7a2c3416.png">


## Before
The error message is `(ArgumentError) You must be in the repository root directory in order to run the tests.`

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/12410942/140602704-9b55de65-a894-49d8-a301-1fc88160c91f.png">

## After
The error message is `(SyntaxError) platform/elixir/mail_checker.ex:3: syntax error before: am`

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/12410942/140602736-08041b9a-a8aa-48af-a46e-84f680d00f0b.png">

