### PR TITLE
improve php lookup performance

### DIFF
--- a/platform/php/MailChecker.php
+++ b/platform/php/MailChecker.php
@@ -40,7 +40,7 @@ class MailChecker
         $domain = end($parts);
 
         foreach (self::allDomainSuffixes($domain) as $domainSuffix) {
-            if (array_key_exists($domainSuffix, self::$blacklist)) {
+            if (isset(self::$blacklist[$domainSuffix])) {
                 return true;
             }
         }


### PR DESCRIPTION
This will improve php lookup performance.

Used benchmark test script:

```php
<?php

declare(strict_types = 1);

function testPerformance($name, Closure $closure, $runs = 1000000)
{
    $start = microtime(true);
    for (; $runs > 0; $runs--) {
        $closure();
    }

    $end = microtime(true);

    printf("Function call %s took %.5f seconds\n", $name, $end - $start);
}

$items = [1111111];
for ($i = 0; $i < 100000; $i++) {
    $items[] = rand(0, 1000000);
}

$items = array_unique($items);
shuffle($items);

$assocItems = array_combine($items, array_fill(0, count($items), true));

$in_array = function () use ($items) {
    in_array(1111111, $items);
};

$isset = function () use ($assocItems) {
    isset($assocItems[1111111]);
};

$array_key_exists = function () use ($assocItems) {
    array_key_exists(1111111, $assocItems);
};

testPerformance('in_array', $in_array, 100000);
testPerformance('isset', $isset, 100000);
testPerformance('array_key_exists', $array_key_exists, 100000);
```

Result:
```
> php test.php
Function call in_array took 4.81913 seconds
Function call isset took 0.01055 seconds
Function call array_key_exists took 0.01091 seconds
```