### PR TITLE
Remove privaterelay.appleid.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -27257,7 +27257,6 @@ privatemail.in
 privatemailinator.nl
 privatemitel.cf
 privatemitel.ml
-privaterelay.appleid.com
 privatesent.tk
 privmag.com
 privy-mail.com


### PR DESCRIPTION
`privaterelay.appleid.com` is used by "Sign in with Apple", which is a login mechanism widely adopted (somehow required) by apps on Apple platform.

This domain addresses actually acts as a relay for real email addresses. User can only obtain an `privaterelay.appleid.com` address by "Sign in with Apple" on 3rd party apps. In other words, `privaterelay.appleid.com`  can't be created as disposable email addresses.

I checked this domain with https://www.mailcheck.ai , and it reports ok with that.