### PR TITLE
Remove @icon.foundation from list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -17402,7 +17402,6 @@ icmarottabasile.it
 icmartiriliberta.it
 icmocozsm.pl
 icnwte.com
-icon.foundation
 iconedit.info
 iconfile.info
 iconmle.com


### PR DESCRIPTION
icon.foundation is a legitimate domain representing [Icon Foundation](https://icon.community). Request instantiated by Eric Solomon - Technical Lead @ Icon Foundation