### PR TITLE
remove untels.edu.pe

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -36053,7 +36053,6 @@ unprographies.xyz
 unrealsoft.tk
 unseen.eu
 unsy3woc.aid.pl
-untels.edu.pe
 untract.com
 untricially.xyz
 uny.kr


### PR DESCRIPTION
http://www.untels.edu.pe/ is a university in Peru. Email addresses are from students, not disposible. (untels.edu.pe looks unexcepted though)