### PR TITLE
removed national university of singapore domain

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -25786,7 +25786,6 @@ nurfuerspam.de
 nurkowania-base.pl
 nurseryschool.ru
 nurularifin.art
-nus.edu.sg
 nut-cc.nut.cc
 nut.cc
 nutcc.nut.cc


### PR DESCRIPTION
It's a real [university](https://nus.edu.sg/)