### PR TITLE
fix(python): use set literal instead of converting list

### DIFF
--- a/platform/python/MailChecker.tmpl.py
+++ b/platform/python/MailChecker.tmpl.py
@@ -9,7 +9,7 @@ if sys.version_info[0] >= 3:
 
 class MailChecker(object):
 
-    blacklist = set([{{& listSTR}}])
+    blacklist = { {{& listSTR}} }
     valid_matcher = re.compile(r"\A{{& unanchoredRegexpString }}\Z")
 
     @classmethod


### PR DESCRIPTION
There might be some memory and performance improvements with directly creating a set instead of coercing one from a list.

(build tested)