### PR TITLE
Update list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -39532,7 +39532,6 @@ privatemailinator.nl
 privatemitel.cf
 privatemitel.ml
 privatemusicteacher.com
-privaterelay.appleid.com
 privatesent.tk
 privmag.com
 privy-mail.com


### PR DESCRIPTION
I removed the domain used by Apple for email forwarding. It is used for privacy concerns. It caused issues in our production. It was introduced in the version 5.0.

Relevant documentation: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/communicating_using_the_private_email_relay_service