### PR TITLE
Update list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -20821,7 +20821,6 @@ giblpyqhb.pl
 gibme.com
 gibsonmail.men
 gicua.com
-gide.com
 gidok.info
 gids.site
 gieldatfi.pl


### PR DESCRIPTION
Hi 👋 

We recently had an issue with the domain `gide.com` that is blocked by this list. It's a french law firm (https://www.gide.com/) and doesn't look like it should be listed here.

I've no idea why it's here but maybe it was previously identified as spam?

Is it possible to remove it?

Thanks!

