### PR TITLE
Remove mozmail again

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -33558,7 +33558,6 @@ mozillafirefox.ga
 mozillafirefox.gq
 mozillafirefox.ml
 mozillafirefox.tk
-mozmail.com
 mozmail.info
 mozzinovo.club
 mozzzi12.com


### PR DESCRIPTION
See https://github.com/FGRibreau/mailchecker/pull/349 . But then this was automatically re-added by this commit https://github.com/FGRibreau/mailchecker/commit/a4124ad90208aa2a2e6163f3cc46052c4d6feebe once again locking off legitimate paying users from signing up for any service that utilizes mailchecker. I have opened a PR to the source https://github.com/nfacha/temporary-email-list/pull/1 so hopefully this doesn't happen again, but in the meantime please let this be removed from mailchecker directly