### PR TITLE
Remove ikmail.com (again)

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -24768,7 +24768,6 @@ ikimaru.com
 ikingbin.com
 ikke.win
 ikkjacket.com
-ikmail.com
 ikoplak.cf
 ikoplak.ga
 ikoplak.gq


### PR DESCRIPTION
It was bought by infomaniak.com

First removed here https://github.com/FGRibreau/mailchecker/commit/d129b5eef5d053046cfc46e42a99b4457ed6309d
Added again here https://github.com/FGRibreau/mailchecker/commit/a4124ad90208aa2a2e6163f3cc46052c4d6feebe