### PR TITLE
Add xgmail.com to list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -53687,6 +53687,7 @@ xgk6dy3eodx9kwqvn.ga
 xgk6dy3eodx9kwqvn.gq
 xgk6dy3eodx9kwqvn.tk
 xglrcflghzt.pl
+xgmail.com
 xgmailoo.com
 xgnowherei.com
 xgrxsuldeu.cf


### PR DESCRIPTION
Thanks for `mailchecker`! Super useful.

A quick PR to add:

- `xgmail.com`, which appears to be another throwaway / temporary / disposable email domain from [online research](https://check-mail.org/domain/xgmail.com/)