### PR TITLE
Add disposable/temporary domain: gufum.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -22058,6 +22058,7 @@ guess.bthow.com
 guesschaussurespascher.com
 guesstimatr.com
 gueto2009.com
+gufum.com
 gug.la
 guge.de
 guglator.com


### PR DESCRIPTION
gufum.com,  appears as a temporary / disposable email domain from [online research](https://check-mail.org/domain/gufum.com/)