### PR TITLE
Add disposable domain: inboxmail.life

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -24992,6 +24992,7 @@ inboxed.pw
 inboxeen.com
 inboxhub.net
 inboxkitten.com
+inboxmail.life
 inboxmail.world
 inboxmails.co
 inboxmails.net


### PR DESCRIPTION
inboxmail.life, appears as a temporary / disposable email domain from [online research](https://check-mail.org/domain/inboxmail.life/)