### PR TITLE
remove icam.fr - university

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -24419,7 +24419,6 @@ ic-cadorago.org
 ic-interiors.com
 ic-osiosopra.it
 ic-vialaurentina710-roma.it
-icam.fr
 icanav.net
 icanfatbike.com
 icantbelieveineedtoexplainthisshit.com


### PR DESCRIPTION
https://www.icam.fr/ is a university. There's contact@icam.fr and students have <first name>.<last name>@<number or faculty>.icam.fr email addresses.