### PR TITLE
fix: remove nytimes.com and 24hourfitness.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -1040,7 +1040,6 @@
 24hbanner.com
 24hinbox.com
 24hotesl.com
-24hourfitness.com
 24hourloans.us
 24hourmail.com
 24hourmail.net
@@ -36180,7 +36179,6 @@ nyoregan09brex.ml
 nypato.com
 nyrmusic.com
 nytaudience.com
-nytimes.com
 nyumail.com
 nyusul.com
 nywcmiftn8hwhj.cf


### PR DESCRIPTION
nytimes.com is home of the New York Times newspaper.

https://24hourfitness.com is home to a legitimate fitness gym in the US

closes #402 