### PR TITLE
Removed sneakemail.com domains again

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -29135,7 +29135,6 @@ lhslhw.com
 lhtstci.com
 lhzoom.com
 liamcyrus.com
-liamekaens.com
 lianhe.in
 liaphoto.com
 liargroup.com
@@ -45020,7 +45019,6 @@ snapboosting.com
 snapunit.com
 snapwet.com
 snasu.info
-sneakemail.com
 sneaker-friends.com
 sneaker-mag.com
 sneaker-shops.com
@@ -45042,8 +45040,6 @@ snipe-mail.bid
 snipemail4u.bid
 snipemail4u.men
 snipemail4u.website
-snkmail.com
-snkml.com
 snl9lhtzuvotv.cf
 snl9lhtzuvotv.ga
 snl9lhtzuvotv.gq


### PR DESCRIPTION
Not temporary
See:
https://github.com/FGRibreau/mailchecker/issues/139
https://github.com/FGRibreau/mailchecker/pull/150
https://github.com/FGRibreau/mailchecker/pull/319
https://github.com/nfacha/temporary-email-list/pull/2