### PR TITLE
Remove swatch.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -46662,7 +46662,6 @@ swanticket.com
 swapfinancebroker.org
 swapinsta.com
 swaps.ml
-swatch.com
 swatteammusic.com
 sweatmail.com
 swedesflyshop.com


### PR DESCRIPTION
Hi, it seems as if the checker aggregated the domain swatch.com which is the official domain of the well known Swiss clock manufacture. Please remove the domain from the list.

Thanks!