### PR TITLE
Adding namespaces for the Mailchecker class on the PHP Platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {
-        "classmap": ["platform/php/MailChecker.php"]
+        "psr-4": {
+            "Fgribreau\\": "platform/php"
+          }
     }
 }

--- a/platform/php/MailChecker.php
+++ b/platform/php/MailChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Fgribreau\PHP;
+
 /**
  * MailChecker
  *


### PR DESCRIPTION
The following points pertain to MailChecker being used in PHP code.

As the library is being loaded via composer, the files get auto-loaded, and using `require` to load them again will be an unnecessary step. This PR aims to use namespaces instead. Some advantages of using namespaces over require statements are

1. Namespace Isolation: Namespaces provide a way to isolate your code from the user's code, reducing the chance of naming conflicts. 
2. Improved Readability: When users import classes or functions via namespaces, their code becomes more readable because they can see exactly where a particular class or function is coming from.
3. Easy Updates: If you need to release a new version of your library with improvements or bug fixes, users can simply update their Composer dependencies, and the latest version of your library will be automatically used.