### PR TITLE
Remove fide.com from list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -18550,7 +18550,6 @@ fickdate-lamou.de
 ficken.de
 fickfotzen.mobi
 fictionsite.com
-fide.com
 fidelium10.com
 fidesrodzinna.pl
 fido.be


### PR DESCRIPTION
The domain [fide.com](https://fide.com/) is the website of the International Chess Federation, therefore not a disposable email address.