### PR TITLE
Fix PHP PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Fgribreau\\": "platform/php"
+            "Fgribreau\\PHP\\": "platform/php"
           }
     }
 }


### PR DESCRIPTION
The recent change to the PSR-4 autoloading configuration for PHP had a slight error which caused it to be broken. In the old configuration, composer expected the MailChecker class to exist at `platform/php/PHP/MailChecker.php`, while it existed at `platform/php/MailChecker.php`. By changing this autoload root, composer is now able to properly locate the class again.

Do let me know if I need to elaborate on something.