### PR TITLE
Update go mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/FGRibreau/mailchecker/v5
+module github.com/FGRibreau/mailchecker/v6
 
 go 1.13


### PR DESCRIPTION
In a project that consumes this package, when trying to upgrade to v6 of mailchecker in golang we see the following error:

```
go: github.com/FGRibreau/mailchecker/v6@v6.0.1: go.mod has non-.../v6 module path "github.com/FGRibreau/mailchecker/v5" (and .../v6/go.mod does not exist) at revision v6.0.1
```

I believe this is because the module in the `go.mod` file has not been upgraded to v6.