### PR TITLE
Remove synami.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -46751,7 +46751,6 @@ symphonyresume.com
 sympleks.pl
 sympstico.ca
 symptoms-diabetes.info
-synami.com
 synapse.foundation
 syncax.com
 synchtradlibac.xyz


### PR DESCRIPTION
Hi there,
our company has issues with signing up on several services that use your external script. Could our domain please be removed from the list?
https://github.com/FGRibreau/mailchecker/blob/master/list.txt - Line 46754: synami.com

Here's more info about us. We are a software company and you can check more about us on our official website: https://synami.com/
Thank you and best regards!