### PR TITLE
Add bayxs.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -7343,6 +7343,7 @@ baylead.com
 bayrjnf.pl
 bayshore.edu
 baytrilfordogs.org
+bayxs.com
 bazaaboom.com
 bazarop.com
 bazavashdom.info


### PR DESCRIPTION
Someone mentioned this domain bayxs.com was a DEA on [my own project](https://github.com/reacherhq/check-if-email-exists), claiming it comes from temp-mail.org. [Seems like spam](https://www.stopforumspam.com/domain/bayxs.com).