### PR TITLE
Remove dallas.gov as it is legitimate domain

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -13187,7 +13187,6 @@ dalevillevfw.com
 daliamodels.pl
 dalins.com
 dallaisd.org
-dallas.gov
 dallascowboysjersey.us
 dallasdaybook.com
 dallasftworthdaybook.com


### PR DESCRIPTION
While unused in the past, `dallas.gov` seems to recently come into legitimate use.


Several examples of `dallas.gov` addresses on this page:
https://dallascityhall.com/government/citycouncil/district13/Pages/default.aspx