### PR TITLE
Adjust .editorconfig to not create a newline at end of list.txt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[list.txt]
+insert_final_newline = false


### PR DESCRIPTION
Seems like there's a number of pull requests which inadvertently add a newline to list.txt.  This is at least partly due to `.editorconfig` dictating that a newline should be added at the end.