### PR TITLE
Exclude net.ua from the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -34935,7 +34935,6 @@ nesy.pl
 net-led.com.pl
 net-list.com
 net-solution.info
-net.ua
 net191.com
 net1mail.com
 net2mail.top


### PR DESCRIPTION
net.ua is a root domain and should not be marked as disposable email domain.
It blocks all domains in that zone.

https://www.net.ua/uk/
