### PR TITLE
fix: correct return type for `blacklist` fn

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,2 +1,2 @@
 export function isValid(email: string): boolean
-export function blacklist(): string[]
+export function blacklist(): Set<string>


### PR DESCRIPTION
The `blacklist` function returns a `Set` of`string`s not `Array` of `string`s.