### PR TITLE
Remove bbox.com from the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -7378,7 +7378,6 @@ bbmail.win
 bbnhbgv.com
 bbograiz.com
 bbokki12.com
-bbox.com
 bboygarage.com
 bboysd.com
 bbq59.xyz


### PR DESCRIPTION
bbox.com is a valid email
https://www.bbox.com/