### PR TITLE
Add 10mail.xyz to the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -353,6 +353,7 @@
 10mail.com
 10mail.org
 10mail.tk
+10mail.xyz
 10mi.org
 10minmail.de
 10minut.com.pl


### PR DESCRIPTION
Adds `10mail.xyz` to the list

https://verifymail.io/domain/10mail.xyz

```
10mail.xyz
is a temporary/disposable email address.
```