### PR TITLE
feat: add expressletter.net to list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -17636,6 +17636,7 @@ expresscafe.info
 expressemail.org
 expressgopher.com
 expresslan24.eu
+expressletter.net
 expressvpna.com
 expresumen.site
 expub.info


### PR DESCRIPTION
https://verifymail.io/domain/expressletter.net

```
expressletter.net
is a temporary/disposable email address.
```