### PR TITLE
Remove buildingradar.com from list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -9506,7 +9506,6 @@ bugmenot.ml
 buildabsnow.com
 building-bridges.com
 buildingfastmuscles.com
-buildingradar.com
 buildingstogo.com
 buildrapport.co
 buildsrepair.ru


### PR DESCRIPTION
buildingradar.com is a valid email domain
https://buildingradar.com/
https://verifymail.io/domain/buildingradar.com