### PR TITLE
[GRANT] aseq.com removed

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -6056,7 +6056,6 @@ asdz2xc1d2sac12.com
 asdz2xcd2sac12.com
 asdzxcd2sac12.com
 aseewr1tryhtu.co.cc
-aseq.com
 aseriales.ru
 aserookadion.uni.cc
 aserrpp.com


### PR DESCRIPTION
Hi,

After discussing this matter with colleague Patrick Ferreira, I have updated your records and removed any mention
of 'aseq.com'. The domain aseq.com previously noted in the list.txt appears to be causing issues when trying to use
organizational email accounts for communication or service access with certain third parties.

Regards,