### PR TITLE
chore: remove my.id and web.id from the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -34054,7 +34054,6 @@ my.blatnet.com
 my.cowsnbullz.com
 my.efxs.ca
 my.hellohappy2.com
-my.id
 my.lakemneadows.com
 my.longaid.net
 my.makingdomes.com
@@ -52301,7 +52300,6 @@ web-sift.com
 web-site-sale.ru
 web-sites-sale.ru
 web.discard-email.cf
-web.id
 web20.club
 web20r.com
 web2mailco.com

--- a/list.txt
+++ b/list.txt
@@ -19966,6 +19966,7 @@ fuwa.li
 fuwamofu.com
 fuwari.be
 fux0ringduh.com
+fuzitea.com
 fuzmail.info
 fvgs.com
 fvhnqf7zbixgtgdimpn.cf
@@ -19990,7 +19991,6 @@ fvurtzuz9s.ga
 fvurtzuz9s.gq
 fvurtzuz9s.ml
 fvurtzuz9s.tk
-fuzitea.com
 fw-nietzsche.cf
 fw-nietzsche.ga
 fw-nietzsche.gq


### PR DESCRIPTION
remove my.id and web.id from the list 

https://verifymail.io/domain/web.id => web.id is safe
https://verifymail.io/domain/my.id => my.id is safe

see https://github.com/FGRibreau/mailchecker/issues/459