### PR TITLE
Remove sneakemail from the list...

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -29169,7 +29169,6 @@ lhslhw.com
 lhtstci.com
 lhzoom.com
 liamcyrus.com
-liamekaens.com
 lianhe.in
 liaphoto.com
 liargroup.com
@@ -45075,7 +45074,6 @@ snapboosting.com
 snapunit.com
 snapwet.com
 snasu.info
-sneakemail.com
 sneaker-friends.com
 sneaker-mag.com
 sneaker-shops.com
@@ -45097,8 +45095,6 @@ snipe-mail.bid
 snipemail4u.bid
 snipemail4u.men
 snipemail4u.website
-snkmail.com
-snkml.com
 snl9lhtzuvotv.cf
 snl9lhtzuvotv.ga
 snl9lhtzuvotv.gq


### PR DESCRIPTION
See #108 #139  #319 

Removing the following non-disposable domains used by sneakemail: 
liamekaens.com
sneakemail.com
snkmail.com
snkml.com