### PR TITLE
add new disposable mail domains

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -5009,6 +5009,7 @@ altel.net
 alterego.life
 altern.biz
 alternavox.net
+altersa.site
 although-soft-sharp-nothing.xyz
 altinbasaknesriyat.com
 altincasino.club
@@ -10340,6 +10341,7 @@ cartelrevolution.de
 cartelrevolution.net
 cartelrevolution.org
 cartelrevolutions.com
+cartep.com
 cartermanufacturing.com
 cartflare.com
 carthagen.edu
@@ -21065,6 +21067,7 @@ gloriousfuturedays.com
 gloservma.com
 glovebranders.com
 glovesprotection.info
+glowarena.com
 glowinbox.info
 glownymail.waw.pl
 glqbsobn8adzzh.cf
@@ -24804,6 +24807,7 @@ ikoplak.cf
 ikoplak.ga
 ikoplak.gq
 ikoplak.ml
+ikowat.com
 ikpz6l.pl
 iku.us
 ikuzus.cf
@@ -24843,6 +24847,7 @@ ilmale.it
 ilmiogenerico.it
 ilnostrogrossograssomatrimoniomolisano.com
 ilobi.info
+iloov.eu
 iloplr.com
 ilopopolp.com
 ilove.com
@@ -36017,6 +36022,7 @@ ntna.luk2.com
 ntschools.com
 ntservices.xyz
 ntslink.net
+ntspace.shop
 ntt.gotdns.ch
 ntub.cf
 ntudofutluxmeoa.cf
@@ -45935,6 +45941,7 @@ starikmail.in
 starkrecords.com
 starlight-breaker.net
 starlit-seas.net
+starmail.net
 starmaker.email
 starnow.tk
 starpl.com
@@ -52955,6 +52962,7 @@ wirawan.cf
 wirawanakhmadi.cf
 wire-shelving.info
 wirefreeemail.com
+wirelay.com
 wireless-alarm-system.info
 wirelesspreviews.com
 wiremail.host

--- a/list.txt
+++ b/list.txt
@@ -21067,7 +21067,6 @@ gloriousfuturedays.com
 gloservma.com
 glovebranders.com
 glovesprotection.info
-glowarena.com
 glowinbox.info
 glownymail.waw.pl
 glqbsobn8adzzh.cf


### PR DESCRIPTION
These are all disposable mail addresses:

- cartep.com https://verifymail.io/domain/cartep.com
- starmail.net https://verifymail.io/domain/starmail.net
- ikowat.com https://verifymail.io/domain/ikowat.com
- ~glowarena.com https://verifymail.io/domain/glowarena.com~ Removed
- altersa.site https://verifymail.io/domain/altersa.site
- iloov.eu https://verifymail.io/domain/iloov.eu
- wirelay.com https://verifymail.io/domain/wirelay.com
- ntspace.shop https://verifymail.io/domain/ntspace.shop

- [x] No existing PRs
- [x] Only changed and commited the `list.txt` file
- [x] Tested locally everything with `npm test`