### PR TITLE
Removed doitagile.com as it seems to be a legit domain now

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -14801,7 +14801,6 @@ doid.com
 doiea.com
 doimmn.com
 dointo.com
-doitagile.com
 doitall.tk
 doix.com
 dokhanan.com


### PR DESCRIPTION
Hi team! Miro uses this list to sync disposable emails in our system.

However, doitagile.com seems to be a legit domain who uses our service and is blocking users to be signed in

This is a PR to remove the domain from the list

Can you please check?

Thank you!