### PR TITLE
Remove roquette.com from list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -42289,7 +42289,6 @@ rophievisioncare.com
 ropolo.com
 roptaoti.com
 ropu.com
-roquette.com
 rorma.site
 rosebearmylove.ru
 rosebird.org


### PR DESCRIPTION
If you edit `list.txt` file, please make sure to follow the below checklist:

* [x] You have verified the domain on https://verifymail.io/domain/roquette.com


Fixes #526