### PR TITLE
Drop support for PHP < 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["fake", "email", "detection", "disposable"],
     "license": "MIT",
     "require": {
-        "php": ">=7.3"
+        "php": ">=8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^12"


### PR DESCRIPTION
There version are **really** EOF'ed. See https://www.php.net/supported-versions.php
