### PR TITLE
Fix Python example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pip install mailchecker
 from MailChecker import MailChecker
 
 if not MailChecker.is_valid('bla@example.com'):
-    print "O RLY !"
+    print("O RLY !")
 ```
 
 Django validator: https://github.com/jonashaag/django-indisposable


### PR DESCRIPTION
Fix print() function syntax in the python example in README.md to work with most installations of python by default.
