### PR TITLE
Removed shitware.nl

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -44315,7 +44315,6 @@ shittymail.ga
 shittymail.gq
 shittymail.ml
 shittymail.tk
-shitware.nl
 shiva-spirit.com
 shiyakila.cf
 shiyakila.ga


### PR DESCRIPTION
This is a personal domain. Not a disposable e-mail provider.

If you edit `list.txt` file, please make sure to follow the below checklist:

* [X] You have verified the domain on https://verifymail.io/domain/shitware.nl


fixed #535