### PR TITLE
Remove tornbanner.com from list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -48892,7 +48892,6 @@ torm.xyz
 tormail.net
 tormail.org
 tormails.com
-tornbanner.com
 torneomail.ga
 tornovi.net
 torontogooseoutlet.com


### PR DESCRIPTION
Hello!
We have a client with `tornbanner.com` domain and it looks valid.

https://verifymail.io/domain/tornbanner.com
