### PR TITLE
remove onit.com from temporary domains

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -36951,7 +36951,6 @@ onhrrzqsubu.pl
 oniaj.com
 oninmail.com
 onionred.com
-onit.com
 onkyo1.com
 onlatedotcom.info
 onligaddes.site


### PR DESCRIPTION
Our customer has verified onit.com domain, but can't use our service, since we treat this domain as temporary. I removed onit.com from the list. 
* [ ] You have verified the domain on https://verifymail.io/domain/<DOMAIN_HERE>
