### PR TITLE
remove dbmail.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -13416,7 +13416,6 @@ dbawgrvxewgn3.gq
 dbawgrvxewgn3.ml
 dbawgrvxewgn3.tk
 dbdrainagenottingham.co.uk
-dbmail.com
 dbo.kr
 dbook.pl
 dboss3r.info


### PR DESCRIPTION
Remove dbtest.com again. Was already removed after previous discussion https://github.com/FGRibreau/mailchecker/pull/232 in 2019 but https://github.com/FGRibreau/mailchecker/commit/a4124ad9 added it back in 2022.


If you edit `list.txt` file, please make sure to follow the below checklist:

* [X] You have verified the domain on https://verifymail.io/domain/dbmail.com
