### PR TITLE
Removed cock.li

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -1668,7 +1668,6 @@
 41uno.com
 41uno.net
 41v1relaxn.com
-420blaze.it
 420gmail.com
 420pure.com
 423gmail.com
@@ -3433,7 +3432,6 @@ aaaaaaaaa.com
 aaaf.ru
 aaamail.online
 aaanime.net
-aaathats3as.com
 aaaw45e.com
 aababes.com
 aabagfdgks.net
@@ -4467,7 +4465,6 @@ airjordanspascher1.com
 airjordansshoes2014.com
 airjordansstocker.com
 airknox.com
-airmail.cc
 airmail.fun
 airmail.nz
 airmail.tech
@@ -11849,7 +11846,6 @@ cobin2hood.com
 cobin2hood.company
 coboe.com
 cocabooka.site
-cocaine.ninja
 cocast.net
 coccx1ajbpsz.cf
 coccx1ajbpsz.ga
@@ -11858,9 +11854,6 @@ coccx1ajbpsz.ml
 coccx1ajbpsz.tk
 cochatz.ga
 cochranmail.men
-cock.email
-cock.li
-cock.lu
 cockpitdigital.com
 coclaims.com
 coco-dive.com
@@ -12805,7 +12798,6 @@ cult-reno.ru
 cultmovie.com
 culturallyconnectedcook.org
 cum.sborra.tk
-cumallover.me
 cumangeblog.net
 cumanuallyo.com
 cumbeeclan.com
@@ -14084,8 +14076,6 @@ dichalorli.xyz
 dichvuseothue.com
 dick.com
 dicknose.com
-dicksinhisan.us
-dicksinmyan.us
 dicksoncountyag.com
 dicountsoccerjerseys.com
 dicyemail.com
@@ -18822,7 +18812,6 @@ firef0x.tk
 fireflies.edu
 firekassa.com
 firema.cf
-firemail.cc
 firemail.com.br
 firemail.org.ua
 firemail.uz.ua
@@ -20631,7 +20620,6 @@ getaviciitickets.com
 getawesomebook.site
 getawesomebooks.site
 getawesomelibrary.site
-getbackinthe.kitchen
 getbreathtaking.com
 getburner.email
 getbusinessontop.com
@@ -23249,7 +23237,6 @@ hitler-adolf.ga
 hitler-adolf.gq
 hitler-adolf.ml
 hitler-adolf.tk
-hitler.rocks
 hitlerbehna.com
 hitmail.co
 hitmail.es
@@ -23562,7 +23549,6 @@ hornytoad.com
 horoscopeblog.com
 horoskopde.com
 horsebarninfo.com
-horsefucker.org
 horsepoops.info
 horserecords.net
 horserecords.org
@@ -30085,8 +30071,6 @@ loveme.com
 lovemeet.faith
 lovemeleaveme.com
 lovemue.com
-loves.dicksinhisan.us
-loves.dicksinmyan.us
 lovesea.gq
 lovesoftware.net
 lovesunglasses.info
@@ -32483,7 +32467,6 @@ memek.ml
 memem.uni.me
 mememail.com
 memequeen.club
-memeware.net
 memkottawaprofilebacks.com
 memoriesphotos.com
 memorygalore.com
@@ -34723,7 +34706,6 @@ nate.co.kr
 nathanielenergy.com
 nati.com
 national-escorts.co.uk
-national.shitposting.agency
 nationalchampionshiplivestream.com
 nationalgardeningclub.com
 nationalgerometrics.com
@@ -35430,7 +35412,6 @@ nifect.com
 nifone.ru
 nigdynieodpuszczaj.pl
 nigeria-nedv.ru
-nigge.rs
 niggetemail.tk
 nightfunmore.online.ctu.edu.gr
 nightmedia.cf
@@ -36073,7 +36054,6 @@ nuevomail.com
 nugaba.com
 nugastore.com
 nukahome.com
-nuke.africa
 nuliferecords.com
 null.k3vin.net
 nullbox.info
@@ -41033,7 +41013,6 @@ rao.kr
 rap-master.ru
 rapa.ga
 rapally.site
-rape.lol
 rapenakyodilakoni.cf
 rapid-guaranteed-payday-loans.co.uk
 rapidbeos.net
@@ -47772,7 +47751,6 @@ tfgphjqzkc.pl
 tfiadvocate.com
 tfinest.com
 tfstaiwan.cloudns.asia
-tfwno.gf
 tfzav6iptxcbqviv.cf
 tfzav6iptxcbqviv.ga
 tfzav6iptxcbqviv.gq
@@ -52071,7 +52049,6 @@ wahab.com
 wahana888.org
 wahch-movies.net
 wahreliebe.li
-waifu.club
 waifu.horse
 wailo.cloudns.asia
 waitingjwo.com
@@ -52136,8 +52113,6 @@ want.poisedtoshrike.com
 want2lov.us
 wantisol.ml
 wantplay.site
-wants.dicksinhisan.us
-wants.dicksinmyan.us
 wantwp.com
 wap-facebook.ml
 wapl.ga

--- a/list.txt
+++ b/list.txt
@@ -1668,6 +1668,7 @@
 41uno.com
 41uno.net
 41v1relaxn.com
+420blaze.it
 420gmail.com
 420pure.com
 423gmail.com
@@ -4465,6 +4466,7 @@ airjordanspascher1.com
 airjordansshoes2014.com
 airjordansstocker.com
 airknox.com
+airmail.cc
 airmail.fun
 airmail.nz
 airmail.tech
@@ -12798,6 +12800,7 @@ cult-reno.ru
 cultmovie.com
 culturallyconnectedcook.org
 cum.sborra.tk
+cumallover.me
 cumangeblog.net
 cumanuallyo.com
 cumbeeclan.com
@@ -14076,6 +14079,8 @@ dichalorli.xyz
 dichvuseothue.com
 dick.com
 dicknose.com
+dicksinhisan.us
+dicksinmyan.us
 dicksoncountyag.com
 dicountsoccerjerseys.com
 dicyemail.com
@@ -18812,6 +18817,7 @@ firef0x.tk
 fireflies.edu
 firekassa.com
 firema.cf
+firemail.cc
 firemail.com.br
 firemail.org.ua
 firemail.uz.ua
@@ -20620,6 +20626,7 @@ getaviciitickets.com
 getawesomebook.site
 getawesomebooks.site
 getawesomelibrary.site
+getbackinthe.kitchen
 getbreathtaking.com
 getburner.email
 getbusinessontop.com
@@ -23237,6 +23244,7 @@ hitler-adolf.ga
 hitler-adolf.gq
 hitler-adolf.ml
 hitler-adolf.tk
+hitler.rocks
 hitlerbehna.com
 hitmail.co
 hitmail.es
@@ -30071,6 +30079,8 @@ loveme.com
 lovemeet.faith
 lovemeleaveme.com
 lovemue.com
+loves.dicksinhisan.us
+loves.dicksinmyan.us
 lovesea.gq
 lovesoftware.net
 lovesunglasses.info
@@ -35412,6 +35422,7 @@ nifect.com
 nifone.ru
 nigdynieodpuszczaj.pl
 nigeria-nedv.ru
+nigge.rs
 niggetemail.tk
 nightfunmore.online.ctu.edu.gr
 nightmedia.cf
@@ -36054,6 +36065,7 @@ nuevomail.com
 nugaba.com
 nugastore.com
 nukahome.com
+nuke.africa
 nuliferecords.com
 null.k3vin.net
 nullbox.info
@@ -41013,6 +41025,7 @@ rao.kr
 rap-master.ru
 rapa.ga
 rapally.site
+rape.lol
 rapenakyodilakoni.cf
 rapid-guaranteed-payday-loans.co.uk
 rapidbeos.net
@@ -47751,6 +47764,7 @@ tfgphjqzkc.pl
 tfiadvocate.com
 tfinest.com
 tfstaiwan.cloudns.asia
+tfwno.gf
 tfzav6iptxcbqviv.cf
 tfzav6iptxcbqviv.ga
 tfzav6iptxcbqviv.gq
@@ -52049,6 +52063,7 @@ wahab.com
 wahana888.org
 wahch-movies.net
 wahreliebe.li
+waifu.club
 waifu.horse
 wailo.cloudns.asia
 waitingjwo.com
@@ -52113,6 +52128,8 @@ want.poisedtoshrike.com
 want2lov.us
 wantisol.ml
 wantplay.site
+wants.dicksinhisan.us
+wants.dicksinmyan.us
 wantwp.com
 wap-facebook.ml
 wapl.ga


### PR DESCRIPTION
This pull request is a follow up to issue #545.
Cock.li no longer has a full list of all of its domains in its webpage. Some are listed in the registration page, others are not.
Here are the ones I believe belong to cock.li:
- 420blaze.it
- aaathats3as.com
- airmail.cc
- cocaine.ninja
- cock.email
- cock.li
- cock.lu
- cumallover.me
- dicksinhisan.us
- dicksinmyan.us
- firemail.cc
- getbackinthe.kitchen
- hitler.rocks
- horsefucker.org
- loves.dicksinhisan.us
- loves.dicksinmyan.us
- memeware.net
- national.shitposting.agency
- nigge.rs
- nuke.africa
- rape.lol
- tfwno.gf
- waifu.club
- wants.dicksinhisan.us
- wants.dicksinmyan.us