### PR TITLE
Please remove freemail.hu from disallow list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -19595,7 +19595,6 @@ freemail-host.info
 freemail.best
 freemail.bid
 freemail.co.pl
-freemail.hu
 freemail.men
 freemail.ms
 freemail.nx.cninfo.net


### PR DESCRIPTION
This domain is a legitimate service (Hungary [EU]), not disposable. I can't use Miro with my old email address. Please help me. Thank you.

If you edit `list.txt` file, please make sure to follow the below checklist:

* [x] You have verified the domain on https://verifymail.io/domain/freemail.hu
