### PR TITLE
added https://avomail.org/ disposable mails

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -6535,6 +6535,7 @@ avmail.xyz
 avocadorecipesforyou.com
 avonco.site
 avonforlady.ru
+avomail.org
 avorybonds.com
 avotron.com
 avp1brunupzs8ipef.cf
@@ -12213,6 +12214,8 @@ connectmail.online
 connr.com
 connriver.net
 conone.ru
+conquer-horizons.online
+conquer-matrix.com
 conservativesagainstbush.com
 consfant.com
 considerinsurance.com
@@ -20489,6 +20492,7 @@ geludkita.ml
 geludkita.tk
 gemail.co
 gemail.com
+gemails.online
 gemail.ru
 gemar-qq.live
 gemarbola.life


### PR DESCRIPTION
If you edit `list.txt` file, please make sure to follow the below checklist:

* [ ] You have verified the domain on https://verifymail.io/domain/avomail.org
* [ ] You have verified the domain on https://verifymail.io/domain/gemails.online
* [ ] You have verified the domain on https://verifymail.io/domain/conquer-matrix.com
* [ ] You have verified the domain on https://verifymail.io/domain/conquer-horizons.online

Although VerifyMail says it’s safe, if you visit https://avomail.org/ you can see that these emails are actually disposable.