### PR TITLE
changed return type to array string

### DIFF
--- a/platform/php/MailChecker.php
+++ b/platform/php/MailChecker.php
@@ -30,7 +30,7 @@ class MailChecker
         return self::validEmail($email) && !self::isBlacklisted($email);
     }
 
-    /** @return array<string, true> */
+    /** @return array<string> */
     public static function blacklist(): array
     {
         return array_keys(self::$blocklist);


### PR DESCRIPTION
This commit updates the annotation to `/** @return array<string> */` 
as suggested by https://github.com/FGRibreau/mailchecker/pull/574#discussion_r2627784279