### PR TITLE
Remove 'wizard.com' from the list

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -53041,7 +53041,6 @@ wix.creou.dev
 wix.ptcu.dev
 wixcmm.com
 wiz2.site
-wizard.com
 wizaz.com
 wizisay.online
 wizisay.site


### PR DESCRIPTION
Remove the following items based on the open issue #572
wizard.com (https://verifymail.io/domain/wizard.com)

 No existing PRs
 Only changed and committed the list.txt file