### PR TITLE
Remove merrygoround.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -32590,7 +32590,6 @@ merry.pink
 merrydresses.com
 merrydresses.net
 merryflower.net
-merrygoround.com
 merumart.com
 mervo.site
 mesotheliomasrates.ml


### PR DESCRIPTION
Remove 'merrygoround.com' from the list

If you edit `list.txt` file, please make sure to follow the below checklist:

* [x] You have verified the domain on https://verifymail.io/domain/<DOMAIN_HERE>
