### PR TITLE
Remove 189.cn and 188.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -587,7 +587,6 @@
 186site.com
 1871188.net
 187gmail.com
-188.com
 188gmail.com
 1895photography.com
 189gmail.com
@@ -51436,7 +51435,6 @@ vip-timeclub.ru
 vip-watches.ru
 vip-watches1.eu
 vip.163.com.org
-vip.188.com
 vip.aiot.eu.org
 vip.cool
 vip.dmtc.press


### PR DESCRIPTION
This pull request removes some legit email services.

- `189.cn` is operated by China Telecom
- `188.com`, `vip.188.com` are operated by NetEase

All of these email services require phone number verification to register and use (`188.com` even requires a paid subscription), have a large user group in China, and should not be considered as disposable email services.

---

If you edit `list.txt` file, please make sure to follow the below checklist:

* [x] You have verified the domain on https://verifymail.io/domain/<DOMAIN_HERE>
