### PR TITLE
Remove Fastmail-operated domains incorrectly listed as disposable

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -18224,7 +18224,6 @@ fastmails.club
 fastmailservice.info
 fastmailtoyougo.site
 fastmazda.com
-fastmessaging.com
 fastmitsubishi.com
 fastmobileemail.win
 fastmoney.pro
@@ -31293,7 +31292,6 @@ mailguard.veinflower.veinflower.xyz
 mailgui.pw
 mailgutter.com
 mailhair.com
-mailhaven.com
 mailhazard.com
 mailhazard.us
 mailherber.com
@@ -35980,7 +35978,6 @@ nospam4.us
 nospamdb.com
 nospamfor.us
 nospammail.bz.cm
-nospammail.net
 nospamme.com
 nospammer.ovh
 nospamthanks.info
@@ -41459,7 +41456,6 @@ realit.co.in
 reality-concept.club
 realjordansforsale.xyz
 really.istrash.com
-reallyfast.info
 reallymymail.com
 realpharmacytechnician.com
 realprol.online
@@ -51380,7 +51376,6 @@ veryday.ch
 veryday.eu
 veryday.info
 verydrunk.co.uk
-veryfast.biz
 verymit.com
 veryprice.co
 veryrealemail.com


### PR DESCRIPTION
Removes 5 domains operated by Fastmail (a legitimate paid email provider) that are incorrectly listed as disposable:

- fastmessaging.com
- mailhaven.com
- nospammail.net
- reallyfast.info
- veryfast.biz

All five resolve to Fastmail's mail servers (messagingengine.com MX records, ASN 151847 - Fastmail Pty Ltd). They are privacy/alias domains, not throwaway addresses.

Closes #609

**Checklist:**
- [x] Verified fastmessaging.com on verifymail.io — Disposable: No, Provider: fastmail.com
- [x] Verified mailhaven.com on verifymail.io — Disposable: No, Provider: fastmail.com
- [x] Verified nospammail.net on verifymail.io — Disposable: No, Provider: fastmail.com
- [x] Verified reallyfast.info on verifymail.io — Disposable: No, Provider: fastmail.com
- [x] Verified veryfast.biz on verifymail.io — Disposable: No, Provider: fastmail.com

These are genuine Fastmail-operated domains used by paying customers. Classifying them as disposable causes legitimate users to be blocked from signing up to services.
Our privacy/alias capability only extends to providing protection for users with genuine accounts on our system - they are long-term and traceable if relevant.  None are disposable or short-term account.
Relates to issue #609.