### PR TITLE
Removal request: zamana.com legitimate corporate domain, listing predates current ownership

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -55592,7 +55592,6 @@ zalmem.com
 zalopner87.com
 zalotti.com
 zalvisual.us
-zamana.com
 zambia-nedv.ru
 zamburu.com
 zamena-stekla.ru


### PR DESCRIPTION
Hi, please remove zamana.com from the list. zamana.com is the corporate email domain of Zamana Inc.

The domain (registered since 2004) was acquired by the company in October 2025; any disposable-email activity predates our ownership. It was first flagged around 2019, years before the company existed.

There is no public email signup or address-generation service on this domain today.

Current setup, publicly verifiable: business email on Google Workspace (MX: smtp.google.com), published SPF and DMARC.

The stale listing is blocking employees from registering for services.

Happy to provide further verification. Thank you!

* [x] You have verified the domain on https://verifymail.io/domain/zamana.com

<img width="1267" height="937" alt="image" src="https://github.com/user-attachments/assets/b85d940d-e3ac-41cc-ba1c-be9910acf9db" />
