### PR TITLE
Remove 'continumail.com' from list.txt false positive

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -12296,7 +12296,6 @@ contbay.com
 contenand.xyz
 contentwanted.com
 contextconversation.com
-continumail.com
 contmy.info
 contopo.com
 contracommunications.com


### PR DESCRIPTION
continumail.com is not a disposable or temporary email provider.

I own the domain and operate the ContinuMail project. The domain does not currently provide any email service, but it may be used for legitimate email services in the future.

At present, the domain hosts the website for ContinuMail Converter, a free and open-source email conversion project.

Website: https://www.continumail.com/

GitHub repository: https://github.com/ContinuMail/continumail-converter

The domain does not provide temporary inboxes, throwaway addresses, or disposable email services. Its inclusion in list.txt is therefore a false positive.

If you edit `list.txt` file, please make sure to follow the below checklist:

* [ x] You have verified the domain on https://verifymail.io/domain/<DOMAIN_HERE>
