### PR TITLE
Remove codingliteracy.com from list.txt (false positive)

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -11981,7 +11981,6 @@ codij.site
 codik.site
 codil.site
 codim.site
-codingliteracy.com
 codip.site
 codiq.site
 codir.site


### PR DESCRIPTION
## Remove codingliteracy.com from list.txt — false positive

Per CONTRIBUTING.md, this PR changes **only `list.txt`**: it removes one line, `codingliteracy.com`.

`codingliteracy.com` is the company domain of **Coding Literacy LLC**, a software company. It is not a disposable email provider.

**Evidence:**

- **Email is paid Google Workspace** — `dig MX codingliteracy.com` returns `10 smtp.google.com.` Disposable providers don't run their mail on paid Workspace accounts.
- **Registered since 2014** (Verisign RDAP), with a company website at https://codingliteracy.com.
- Google site verification and transactional-email (Brevo) TXT records are in place — the DNS footprint of an operating business, not a temp-mail service.

The entry appears to have been imported from wesbos/burner-email-providers; a matching removal PR has been filed there as well.

**Impact:** because mailchecker feeds the disposable/disposable aggregate consumed by most email verifiers, the company's staff addresses are currently rejected at signup by services such as Steam ("It appears you've entered a disposable email address...").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV6HcRm37d98N5tVwCCZE7
