### PR TITLE
#617 Update emails.txt to remove aver.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -6527,7 +6527,6 @@ ave-kingdom.com
 avengersfanboygirlongirl.com
 avenuebb.com
 avenuesilver.com
-aver.com
 averdov.com
 averedlest.monster
 averite.com


### PR DESCRIPTION
aver.com is the official domain of AVer Information Inc.

If you edit `list.txt` file, please make sure to follow the below checklist:

<img width="1447" height="857" alt="image" src="https://github.com/user-attachments/assets/4b0da7ea-9cfc-4933-852d-77e8bcf25bcd" />

* [x] You have verified the domain on https://verifymail.io/domain/aver.com
