### PR TITLE
fix(list): remove improvmx.com, legitimate email forwarding service, not disposable

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -25172,7 +25172,6 @@ imprimtout.com
 imprisonedwithisis.com
 improvedtt.com
 improvidents.xyz
-improvmx.com
 imrekoglukoleksiyon.xyz
 imsave.com
 imsend.ru


### PR DESCRIPTION
Removes `improvmx.com` from `list.txt`.

improvmx.com is not a disposable email provider, It's an email forwarding service.

Using ImprovMX to generate disposable emails is explicitly against the company's [terms of service](https://improvmx.com/transparency/terms-of-service/).

Domains are tied to registered accounts, which are regularly monitored by our abuse team, as part of the company's [abuse detection](https://improvmx.com/transparency/deliverability-and-abuse-detection/).

Blocking causes signup failures for legitimate people using their own domains to forward email, since downstream consumers treat the whole list as disposable.

